### PR TITLE
fix utf-8 output file encoding

### DIFF
--- a/blinkist/book.py
+++ b/blinkist/book.py
@@ -123,7 +123,7 @@ class Book:
         markdown_text = "\n\n\n".join(parts)
 
         file_path = target_dir / f"{FILENAME_TEXT}.md"
-        file_path.write_text(markdown_text)
+        file_path.write_text(markdown_text, encoding="utf-8")
 
     def serialize(self) -> dict:
         """
@@ -146,4 +146,4 @@ class Book:
             self.serialize(),
             default_flow_style=False,
             allow_unicode=True,
-        ))
+        ), encoding="utf-8")

--- a/blinkist/book.py
+++ b/blinkist/book.py
@@ -123,7 +123,7 @@ class Book:
         markdown_text = "\n\n\n".join(parts)
 
         file_path = target_dir / f"{FILENAME_TEXT}.md"
-        file_path.write_text(markdown_text, encoding="utf-8")
+        file_path.write_text(markdown_text, encoding='utf-8')
 
     def serialize(self) -> dict:
         """
@@ -142,8 +142,11 @@ class Book:
         Downloads the raw YAML to the given directory.
         """
         file_path = target_dir / f"{FILENAME_RAW}.yaml"
-        file_path.write_text(yaml.dump(
-            self.serialize(),
-            default_flow_style=False,
-            allow_unicode=True,
-        ), encoding="utf-8")
+        file_path.write_text(
+            yaml.dump(
+                self.serialize(),
+                default_flow_style=False,
+                allow_unicode=True,
+            ),
+            encoding='utf-8',
+        )


### PR DESCRIPTION
Fix `UnicodeEncodeError: 'charmap' codec can't encode character` on Windows